### PR TITLE
fix division by zero in normalizing

### DIFF
--- a/src/Vector2.elm
+++ b/src/Vector2.elm
@@ -1,6 +1,7 @@
 module Vector2 exposing (..)
 
 {-|
+
 @docs Float2, Vec2
 
 @docs setX, setY, getX, getY, map, map2, foldl, foldr
@@ -8,6 +9,7 @@ module Vector2 exposing (..)
 @docs add, sub, negate, scale, divideBy
 
 @docs dot, length, lengthSquared, normalize, directionFromTo, distance, distanceSquared, angle, project, reject
+
 -}
 
 
@@ -50,7 +52,9 @@ setY a ( x, y ) =
 
 
 {-|
+
     map ((+) 1) (2,3) == (3,4)
+
 -}
 map : (a -> b) -> Vec2 a -> Vec2 b
 map f ( x, y ) =
@@ -58,7 +62,9 @@ map f ( x, y ) =
 
 
 {-|
+
     map2 (*) (2,4) (3,2) == (6,8)
+
 -}
 map2 : (a -> b -> c) -> Vec2 a -> Vec2 b -> Vec2 c
 map2 op ( x1, y1 ) ( x2, y2 ) =
@@ -66,7 +72,9 @@ map2 op ( x1, y1 ) ( x2, y2 ) =
 
 
 {-|
+
     foldl (+) 0 (2,4) == 6
+
 -}
 foldl : (elem -> acc -> acc) -> acc -> Vec2 elem -> acc
 foldl f start ( x, y ) =
@@ -74,7 +82,9 @@ foldl f start ( x, y ) =
 
 
 {-|
+
     foldr (-) 0 (1,12) == -11
+
 -}
 foldr : (elem -> acc -> acc) -> acc -> Vec2 elem -> acc
 foldr f start ( x, y ) =
@@ -88,6 +98,7 @@ foldr f start ( x, y ) =
 {-| `v + w`
 
     add (1,2) (4,5) == (5,7)
+
 -}
 add : Float2 -> Float2 -> Float2
 add ( x1, y1 ) ( x2, y2 ) =
@@ -97,6 +108,7 @@ add ( x1, y1 ) ( x2, y2 ) =
 {-| `v - w`
 
     sub (3,1) (-3,8) == (6,-7)
+
 -}
 sub : Float2 -> Float2 -> Float2
 sub ( x1, y1 ) ( x2, y2 ) =
@@ -106,6 +118,7 @@ sub ( x1, y1 ) ( x2, y2 ) =
 {-| `-v`
 
     negate (2,-4) == (-2,4)
+
 -}
 negate : Float2 -> Float2
 negate ( x, y ) =
@@ -114,7 +127,9 @@ negate ( x, y ) =
 
 {-| `a*v`
 
-    scale 3 (2,3) = (6,9)
+    scale 3 ( 2, 3 ) =
+        ( 6, 9 )
+
 -}
 scale : Float -> Float2 -> Float2
 scale a ( x, y ) =
@@ -124,6 +139,7 @@ scale a ( x, y ) =
 {-| `v/a`
 
     divideBy 4 (12,16) == (3,4)
+
 -}
 divideBy : Float -> Float2 -> Float2
 divideBy a ( x, y ) =
@@ -139,6 +155,7 @@ It links the length and angle of two vectors.
 `v dot w = |v|*|w|*cos(phi)`
 
     dot (1,2) (3,2) == 1*3 + 2*2 == 7
+
 -}
 dot : Float2 -> Float2 -> Float
 dot ( x1, y1 ) ( x2, y2 ) =
@@ -150,6 +167,7 @@ dot ( x1, y1 ) ( x2, y2 ) =
 `(v dot w)/|w| * w/|w|`
 
     project (2,1) (4,0) == (2,0)
+
 -}
 project : Float2 -> Float2 -> Float2
 project v w =
@@ -157,7 +175,7 @@ project v w =
         l_w =
             lengthSquared w
     in
-        scale ((dot v w) / l_w) w
+    scale (dot v w / l_w) w
 
 
 {-| The rejection of `v` onto `w`. This is always perpendicular to the projection.
@@ -165,6 +183,7 @@ project v w =
 `v - (project v w)`
 
     reject (2,1) (4,0) == (0,1)
+
 -}
 reject : Float2 -> Float2 -> Float2
 reject v w =
@@ -176,6 +195,7 @@ reject v w =
 `|v| = sqrt(v dot v)`
 
     length (3,4) == sqrt(3^2+4^2) == 5
+
 -}
 length : Float2 -> Float
 length v =
@@ -188,6 +208,7 @@ so if you only need to compare lengths you can use this instead of the length.
 `|v|^2 = v dot w`
 
     lengthSquared (3,4) == 3^2+4^2 == 25
+
 -}
 lengthSquared : Float2 -> Float
 lengthSquared v =
@@ -199,10 +220,14 @@ lengthSquared v =
 `v/|v|`
 
     normalize (3,4) == (3/5,4/5)
+
 -}
 normalize : Float2 -> Float2
 normalize v =
-    divideBy (length v) v
+    if length v == 0 then
+        v
+    else
+        divideBy (length v) v
 
 
 {-| A unit vector pointing from `v` to `w`
@@ -210,6 +235,7 @@ normalize v =
 `(w - v)/|w - v|`
 
     directionFromTo (5,1) (8,5) == (3/5,4/5)
+
 -}
 directionFromTo : Float2 -> Float2 -> Float2
 directionFromTo v w =
@@ -221,6 +247,7 @@ directionFromTo v w =
 `|v - w| = |w - v|`
 
     distance (3,0) (0,4) == 5
+
 -}
 distance : Float2 -> Float2 -> Float
 distance v w =
@@ -232,6 +259,7 @@ distance v w =
 `|v - w|^2`
 
     distanceSquared (3,0) (0,4) == 25
+
 -}
 distanceSquared : Float2 -> Float2 -> Float
 distanceSquared v w =
@@ -243,6 +271,7 @@ distanceSquared v w =
 `acos((v dot w)/(|v|*|w|))`
 
     angle (1,0) (2,2) == pi/4    -- or 45°
+
 -}
 angle : Float2 -> Float2 -> Float
 angle v w =
@@ -250,7 +279,7 @@ angle v w =
         r =
             dot v w / (length v * length w)
     in
-        if r >= 1 then
-            0
-        else
-            acos r
+    if r >= 1 then
+        0
+    else
+        acos r

--- a/src/Vector3.elm
+++ b/src/Vector3.elm
@@ -1,6 +1,7 @@
 module Vector3 exposing (..)
 
 {-|
+
 @docs Float3, Vec3
 
 @docs fromV2, setX, setY, setZ, getX, getY, getZ, map, map2, foldl, foldr
@@ -8,6 +9,7 @@ module Vector3 exposing (..)
 @docs add, sub, negate, scale, divideBy
 
 @docs dot, cross, length, lengthSquared, normalize, directionFromTo, distance, distanceSquared, angle, project, reject
+
 -}
 
 import Vector2 exposing (Vec2)
@@ -28,7 +30,9 @@ type alias Float3 =
 
 
 {-|
+
     fromV2 (1,2) 3 == (1,2,3)
+
 -}
 fromV2 : Vec2 a -> a -> Vec3 a
 fromV2 ( x, y ) z =
@@ -72,7 +76,9 @@ setZ a ( x, y, z ) =
 
 
 {-|
+
     map sqrt (1,4,9) == (1,2,3)
+
 -}
 map : (a -> b) -> Vec3 a -> Vec3 b
 map f ( x, y, z ) =
@@ -80,7 +86,9 @@ map f ( x, y, z ) =
 
 
 {-|
+
     map2 (/) (4,9,12) (2,3,4) == (2,3,3)
+
 -}
 map2 : (a -> b -> c) -> Vec3 a -> Vec3 b -> Vec3 c
 map2 f ( x1, y1, z1 ) ( x2, y2, z2 ) =
@@ -88,7 +96,9 @@ map2 f ( x1, y1, z1 ) ( x2, y2, z2 ) =
 
 
 {-|
+
     foldl (*) 1 (2,4,1) == 8
+
 -}
 foldl : (elem -> acc -> acc) -> acc -> Vec3 elem -> acc
 foldl f start ( x, y, z ) =
@@ -96,7 +106,9 @@ foldl f start ( x, y, z ) =
 
 
 {-|
+
     foldr max 0 (1,12,-5) == 12
+
 -}
 foldr : (elem -> acc -> acc) -> acc -> Vec3 elem -> acc
 foldr f start ( x, y, z ) =
@@ -110,6 +122,7 @@ foldr f start ( x, y, z ) =
 {-| `v + w`
 
     add (2,4,1) (3,-6,2) == (5,-2,3)
+
 -}
 add : Float3 -> Float3 -> Float3
 add ( x1, y1, z1 ) ( x2, y2, z2 ) =
@@ -119,6 +132,7 @@ add ( x1, y1, z1 ) ( x2, y2, z2 ) =
 {-| `v - w`
 
     sub (4,6,1) (3,-1,-4) == (1,7,5)
+
 -}
 sub : Float3 -> Float3 -> Float3
 sub ( x1, y1, z1 ) ( x2, y2, z2 ) =
@@ -128,6 +142,7 @@ sub ( x1, y1, z1 ) ( x2, y2, z2 ) =
 {-| `-v`
 
     negate (2,-1,5) == (-2,1,-5)
+
 -}
 negate : Float3 -> Float3
 negate ( x, y, z ) =
@@ -137,6 +152,7 @@ negate ( x, y, z ) =
 {-| `a*v`
 
     scale (1/2) (4,2,6) == (2,1,3)
+
 -}
 scale : Float -> Float3 -> Float3
 scale a ( x, y, z ) =
@@ -146,6 +162,7 @@ scale a ( x, y, z ) =
 {-| `v/a`
 
     divideBy (1/2) (2,1,3) == (4,2,6)
+
 -}
 divideBy : Float -> Float3 -> Float3
 divideBy a ( x, y, z ) =
@@ -161,6 +178,7 @@ It links the length and angle of two vectors.
 `v dot w = |v|*|w|*cos(phi)`
 
     dot (1,2,2) (3,3,2) == 1*3 + 2*3 + 2*2 == 13
+
 -}
 dot : Float3 -> Float3 -> Float
 dot ( x1, y1, z1 ) ( x2, y2, z2 ) =
@@ -179,6 +197,7 @@ The length of `v cross w` is equal to the area of the parallelogram spanned by `
 `|v cross w| = |v|*|w|*sin(phi)`
 
     cross (2,1,3) (4,5,-3) == (1*(-3) - 3*5, 3*4 - 2*(-3), 2*5 - 1*4) == (-18, 18, 6)
+
 -}
 cross : Float3 -> Float3 -> Float3
 cross ( x1, y1, z1 ) ( x2, y2, z2 ) =
@@ -190,6 +209,7 @@ cross ( x1, y1, z1 ) ( x2, y2, z2 ) =
 `|v| = sqrt(v dot v)`
 
     length (4,2,4) == sqrt (4^2+2^2+4^2) == 6
+
 -}
 length : Float3 -> Float
 length v =
@@ -202,6 +222,7 @@ so if you only need to compare lengths you can use this instead of the length.
 `|v|^2 = v dot w`
 
     lengthSquared (3,4,1) == 3^2+4^2+1^2 == 26
+
 -}
 lengthSquared : Float3 -> Float
 lengthSquared v =
@@ -213,10 +234,14 @@ lengthSquared v =
 `v/|v|`
 
     normalize (4,2,4) == (2/3,1/3,2/3)
+
 -}
 normalize : Float3 -> Float3
 normalize v =
-    divideBy (length v) v
+    if length v == 0 then
+        v
+    else
+        divideBy (length v) v
 
 
 {-| The projection of `v` onto `w`.
@@ -224,6 +249,7 @@ normalize v =
 `(v dot w)/|w| * w/|w|`
 
     project (2,1,0) (4,0,0) == (2,0,0)
+
 -}
 project : Float3 -> Float3 -> Float3
 project v w =
@@ -231,7 +257,7 @@ project v w =
         l_w =
             lengthSquared w
     in
-        scale ((dot v w) / l_w) w
+    scale (dot v w / l_w) w
 
 
 {-| The rejection of `v` onto `w`. This is always perpendicular to the projection.
@@ -239,6 +265,7 @@ project v w =
 `v - (project v w)`
 
     reject (2,1,0) (4,0,0) == (0,1,0)
+
 -}
 reject : Float3 -> Float3 -> Float3
 reject v w =
@@ -250,6 +277,7 @@ reject v w =
 `(w - v)/|w - v|`
 
     directionFromTo (5,1,2) (9,3,6) == (2/3,1/3,2/3)
+
 -}
 directionFromTo : Float3 -> Float3 -> Float3
 directionFromTo a b =
@@ -261,6 +289,7 @@ directionFromTo a b =
 `|v - w| = |w - v|`
 
     distance (2,0,4) (0,4,0) == 6
+
 -}
 distance : Float3 -> Float3 -> Float
 distance a b =
@@ -272,6 +301,7 @@ distance a b =
 `|v - w|^2`
 
     distanceSquared (3,0,2) (0,4,1) == 26
+
 -}
 distanceSquared : Float3 -> Float3 -> Float
 distanceSquared a b =
@@ -283,6 +313,7 @@ distanceSquared a b =
 `acos((v dot w)/(|v|*|w|))`
 
     angle (-1,-1,2) (2,2,2) == pi/2    -- or 90°
+
 -}
 angle : Float3 -> Float3 -> Float
 angle a b =
@@ -290,7 +321,7 @@ angle a b =
         r =
             dot a b / (length a * length b)
     in
-        if r >= 1 then
-            0
-        else
-            acos r
+    if r >= 1 then
+        0
+    else
+        acos r

--- a/src/Vector4.elm
+++ b/src/Vector4.elm
@@ -1,6 +1,7 @@
 module Vector4 exposing (..)
 
 {-|
+
 @docs Float4, Vec4
 
 @docs fromV3, setX, setY, setZ, setW, getX, getY, getZ, getW, map, map2, foldl, foldr
@@ -8,6 +9,7 @@ module Vector4 exposing (..)
 @docs add, sub, negate, scale, divideBy
 
 @docs dot, length, lengthSquared, normalize, directionFromTo, distance, distanceSquared, angle
+
 -}
 
 import Vector3 exposing (Vec3)
@@ -28,7 +30,9 @@ type alias Float4 =
 
 
 {-|
+
     fromV3 (1,2,3) 1 == (1,2,3,1)
+
 -}
 fromV3 : Vec3 a -> a -> Vec4 a
 fromV3 ( x, y, z ) w =
@@ -84,7 +88,9 @@ setW a ( x, y, z, w ) =
 
 
 {-|
+
     map (\x -> x^2) (1,2,3,4) == (1,4,9,16)
+
 -}
 map : (a -> b) -> Vec4 a -> Vec4 b
 map f ( x, y, z, w ) =
@@ -92,7 +98,9 @@ map f ( x, y, z, w ) =
 
 
 {-|
+
     map2 (<) (2,1,4,2) (3,2,1,6) == (True, True, False, True)
+
 -}
 map2 : (a -> b -> c) -> Vec4 a -> Vec4 b -> Vec4 c
 map2 f ( x1, y1, z1, w1 ) ( x2, y2, z2, w2 ) =
@@ -100,7 +108,9 @@ map2 f ( x1, y1, z1, w1 ) ( x2, y2, z2, w2 ) =
 
 
 {-|
+
     foldl (\elem acc -> acc + elem^2) 0 (2,4,1,2) == 25
+
 -}
 foldl : (elem -> acc -> acc) -> acc -> Vec4 elem -> acc
 foldl f start ( x, y, z, w ) =
@@ -108,7 +118,9 @@ foldl f start ( x, y, z, w ) =
 
 
 {-|
+
     foldr (::) [] (1,2,3,5) == [1,2,3,5]
+
 -}
 foldr : (elem -> acc -> acc) -> acc -> Vec4 elem -> acc
 foldr f start ( x, y, z, w ) =
@@ -122,6 +134,7 @@ foldr f start ( x, y, z, w ) =
 {-| `v + w`
 
     add (2,4,1,-2) (3,-6,2,1) == (5,-2,3,-1)
+
 -}
 add : Float4 -> Float4 -> Float4
 add ( x1, y1, z1, w1 ) ( x2, y2, z2, w2 ) =
@@ -131,6 +144,7 @@ add ( x1, y1, z1, w1 ) ( x2, y2, z2, w2 ) =
 {-| `v - w`
 
     sub (4,6,1,2) (3,-1,-4,4) == (1,7,5,-2)
+
 -}
 sub : Float4 -> Float4 -> Float4
 sub ( x1, y1, z1, w1 ) ( x2, y2, z2, w2 ) =
@@ -140,6 +154,7 @@ sub ( x1, y1, z1, w1 ) ( x2, y2, z2, w2 ) =
 {-| `-v`
 
     negate (2,-1,5,1) == (-2,1,-5,-1)
+
 -}
 negate : Float4 -> Float4
 negate ( x, y, z, w ) =
@@ -149,6 +164,7 @@ negate ( x, y, z, w ) =
 {-| `a*v`
 
     scale (3/2) (4,2,6,10) == (6,3,9,15)
+
 -}
 scale : Float -> Float4 -> Float4
 scale a ( x, y, z, w ) =
@@ -158,6 +174,7 @@ scale a ( x, y, z, w ) =
 {-| `v/a`
 
     divideBy (3/2) (3,12,6,9) == (2,8,4,6)
+
 -}
 divideBy : Float -> Float4 -> Float4
 divideBy a ( x, y, z, w ) =
@@ -173,6 +190,7 @@ It links the length and angle of two vectors.
 `v dot w = |v|*|w|*cos(phi)`
 
     dot (1,2,2,3) (3,3,2,2) == 1*3 + 2*3 + 2*2 + 3*2 == 19
+
 -}
 dot : Float4 -> Float4 -> Float
 dot ( x1, y1, z1, w1 ) ( x2, y2, z2, w2 ) =
@@ -184,6 +202,7 @@ dot ( x1, y1, z1, w1 ) ( x2, y2, z2, w2 ) =
 `|v| = sqrt(v dot v)`
 
     length (2,4,1,2) == sqrt (2^2+4^2+1^2+2^2) == 5
+
 -}
 length : Float4 -> Float
 length v =
@@ -196,6 +215,7 @@ so if you only need to compare lengths you can use this instead of the length.
 `|v|^2 = v dot w`
 
     lengthSquared (3,4,1,2) == 3^2+4^2+1^2+2^2 == 30
+
 -}
 lengthSquared : Float4 -> Float
 lengthSquared v =
@@ -207,10 +227,14 @@ lengthSquared v =
 `v/|v|`
 
     normalize (2,4,1,2) == (2/5,4/5,1/5,2/5)
+
 -}
 normalize : Float4 -> Float4
 normalize v =
-    divideBy (length v) v
+    if length v == 0 then
+        v
+    else
+        divideBy (length v) v
 
 
 {-| A unit vector pointing from `v` to `w`
@@ -218,6 +242,7 @@ normalize v =
 `(w - v)/|w - v|`
 
     directionFromTo (5,1,2,4) (7,5,3,6) == (2/5,4/5,1/5,2/5)
+
 -}
 directionFromTo : Float4 -> Float4 -> Float4
 directionFromTo a b =
@@ -229,6 +254,7 @@ directionFromTo a b =
 `|v - w| = |w - v|`
 
     distance (7,5,3,6) (5,1,2,4) == 5
+
 -}
 distance : Float4 -> Float4 -> Float
 distance a b =
@@ -240,6 +266,7 @@ distance a b =
 `|v - w|^2`
 
     distanceSquared (3,0,2,1) (0,2,4,1) == 17
+
 -}
 distanceSquared : Float4 -> Float4 -> Float
 distanceSquared a b =
@@ -251,6 +278,7 @@ distanceSquared a b =
 `acos((v dot w)/(|v|*|w|))`
 
     angle (-1,-1,2,0) (2,2,2,0) == pi/2    -- or 90°
+
 -}
 angle : Float4 -> Float4 -> Float
 angle a b =
@@ -258,7 +286,7 @@ angle a b =
         r =
             dot a b / (length a * length b)
     in
-        if r >= 1 then
-            0
-        else
-            acos r
+    if r >= 1 then
+        0
+    else
+        acos r


### PR DESCRIPTION
I don't know if you are still developing this as the latest change was in 2016. This is the only vector math library I found that installs on Elm 0.18.

If yes, you should update your version of elm-test and elm-format. I was not able to run the tests.